### PR TITLE
fixes #4 caused by CP's liberal unpack

### DIFF
--- a/adafruit_max31856.py
+++ b/adafruit_max31856.py
@@ -132,7 +132,7 @@ class MAX31856:
 
     # A class level buffer to reduce allocations for reading and writing.
     # Tony says this isn't re-entrant or thread safe!
-    _BUFFER = bytearray(3)
+    _BUFFER = bytearray(4)
 
     def __init__(self, spi, cs, thermocouple_type=ThermocoupleType.K):
         self._device = SPIDevice(spi, cs, baudrate=500000, polarity=0, phase=1)


### PR DESCRIPTION
This should fix the issue; As far as I can  tell CP's `unpack` is filling in the missing byte which we are already shifting away, so increasing `_BUFFER` to 4 bytes allows CPython's `unpack` to not barf and the garbage extra byte at the end isn't a problem.

I tested that it works in Python 3 by pasting and example `_BUFFER` into a REPL and finishing the conversion by hand, but if someone can double check on an RPi or similar that would be swell.

```
~$ python3
Python 3.7.0 (default, Sep 25 2018, 01:24:12)
[Clang 7.0.2 (clang-700.1.81)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> raw = bytearray(b'\x01P ')
>>> from struct import unpack
>>> unpack(">i", raw)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
struct.error: unpack requires a buffer of 4 bytes
>>> unpack(">i", bytearray(b'\x01I\xa0\x00'))
(21602304,)
>>> len(bytearray(b'\x01I\xa0\x00'))
4
>>> unpack(">i", bytearray(b'\x01I\xa0\x00'))
(21602304,)
>>> unpack(">i", bytearray(b'\x01I\xa0\x00'))[0]>>8
84384
>>> (unpack(">i", bytearray(b'\x01I\xa0\x00'))[0]>>8)/4096.0
20.6015625
```

An example of CP's `unpack` behavior:
```
>>> unpack(">i", bytearray([1,0,0,0]))
(16777216,)
>>> unpack(">i", bytearray([1,0,0]))
(16777216,)
>>> unpack(">i", bytearray([1,0]))
(16777216,)
>>> unpack(">i", bytearray([1]))
(16777216,)
```