### PR TITLE
Update _read_register

### DIFF
--- a/adafruit_max31856.py
+++ b/adafruit_max31856.py
@@ -156,7 +156,7 @@ class MAX31856:
         self._perform_one_shot_measurement()
 
         # unpack the 3-byte temperature as 4 bytes
-        raw_temp = unpack(">i", self._read_register(_MAX31856_LTCBH_REG, 3))[0]
+        raw_temp = unpack(">i", self._read_register(_MAX31856_LTCBH_REG, 3)+bytes([0]))[0]
 
         # shift to remove extra byte from unpack needing 4 bytes
         raw_temp >>= 8
@@ -271,7 +271,7 @@ class MAX31856:
             self._BUFFER[0] = address & 0x7F
             device.write(self._BUFFER, end=1)
             device.readinto(self._BUFFER, end=length)
-        return self._BUFFER
+        return self._BUFFER[:length]
 
     def _write_u8(self, address, val):
         # Write an 8-bit unsigned value to the specified 8-bit address.


### PR DESCRIPTION
Another fix for #4, which was closed but recently popped back up on radar.

Return matches requested length to better align with use of `unpack`.
```python
pi@pizerow:~/repos/Adafruit_CircuitPython_MAX31856 $ python3
Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board, busio
>>> import digitalio
>>> import adafruit_max31856
>>> spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
>>> cs = digitalio.DigitalInOut(board.D21)
>>> cs.direction = digitalio.Direction.OUTPUT
>>> tc = adafruit_max31856.MAX31856(spi, cs)
>>> tc.temperature
22.1796875
>>> tc.reference_temperature
22.828125
>>>
```