### PR TITLE
Improve speed of temperature retrieval and allow non-blocking measurement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,9 +70,16 @@ Usage Example
       # create a thermocouple object with the above
       thermocouple = adafruit_max31856.MAX31856(spi, cs)
 
-      # print the temperature!
+      # measure the temperature! (takes approx 160ms)
       print(thermocouple.temperature)
 
+      # alternative (non-blocking) way to get temperature
+      thermocouple.initiate_one_shot_measurement()
+      # <perform other tasks>
+      # now wait for measurement to complete
+      while thermocouple.oneshot_pending:
+        pass
+      print(thermocouple.unpack_temperature())
 
 Documentation
 =============

--- a/adafruit_max31856.py
+++ b/adafruit_max31856.py
@@ -164,9 +164,12 @@ class MAX31856:
 
     @property
     def temperature(self):
-        """The temperature of the sensor and return its value in degrees Celsius. (read-only)"""
+        """Measure the temperature of the sensor and wait to retrieve its value in degrees Celsius. (read-only)"""
         self._perform_one_shot_measurement()
+        return self.unpack_temperature()
 
+    def unpack_temperature(self) -> float:
+        '''Reads the probe temperature from the register'''
         # unpack the 3-byte temperature as 4 bytes
         raw_temp = unpack(
             ">i", self._read_register(_MAX31856_LTCBH_REG, 3) + bytes([0])
@@ -180,11 +183,16 @@ class MAX31856:
 
         return temp_float
 
+
+
     @property
     def reference_temperature(self):
-        """The temperature of the cold junction in degrees Celsius. (read-only)"""
+        """Wait to retreive temperature of the cold junction in degrees Celsius. (read-only)"""
         self._perform_one_shot_measurement()
+        return self.unpack_reference_temperature()
 
+    def unpack_reference_temperature(self) -> float:
+        '''Reads the reference temperature from the register'''
         raw_read = unpack(">h", self._read_register(_MAX31856_CJTH_REG, 2))[0]
 
         # effectively shift raw_read >> 8 to convert pseudo-float
@@ -264,8 +272,17 @@ class MAX31856:
         }
 
     def _perform_one_shot_measurement(self):
+        self.initiate_one_shot_measurement()
+        # wait for the measurement to complete
+        self._wait_for_oneshot()
 
-        self._write_u8(_MAX31856_CJTO_REG, 0x0)
+
+    def initiate_one_shot_measurement(self):
+        '''Starts a one-shot measurement and returns immediately.
+        A measurement takes approximately 160ms. 
+        Check the status of the measurement with `oneshot_pending`; when it is false,
+        the measurement is complete and the value can be read with `unpack_temperature`.
+        '''
         # read the current value of the first config register
         conf_reg_0 = self._read_register(_MAX31856_CR0_REG, 1)[0]
 
@@ -277,7 +294,18 @@ class MAX31856:
         # write it back with the new values, prompting the sensor to perform a measurement
         self._write_u8(_MAX31856_CR0_REG, conf_reg_0)
 
-        sleep(0.250)
+
+    @property
+    def oneshot_pending(self) -> bool:
+        '''A boolean indicating the status of the one-shot flag. 
+            A True value means the measurement is still ongoing. A False value means measurement is complete.'''
+        oneshot_flag = self._read_register(_MAX31856_CR0_REG, 1)[0] & _MAX31856_CR0_1SHOT
+        return bool(oneshot_flag)
+
+    def _wait_for_oneshot(self):
+        while self.oneshot_pending:
+            sleep(0.01)
+
 
     def _read_register(self, address, length):
         # pylint: disable=no-member

--- a/adafruit_max31856.py
+++ b/adafruit_max31856.py
@@ -170,7 +170,7 @@ class MAX31856:
         return self.unpack_temperature()
 
     def unpack_temperature(self) -> float:
-        '''Reads the probe temperature from the register'''
+        """Reads the probe temperature from the register"""
         # unpack the 3-byte temperature as 4 bytes
         raw_temp = unpack(
             ">i", self._read_register(_MAX31856_LTCBH_REG, 3) + bytes([0])
@@ -184,8 +184,6 @@ class MAX31856:
 
         return temp_float
 
-
-
     @property
     def reference_temperature(self):
         """Wait to retreive temperature of the cold junction in degrees Celsius. (read-only)"""
@@ -193,7 +191,7 @@ class MAX31856:
         return self.unpack_reference_temperature()
 
     def unpack_reference_temperature(self) -> float:
-        '''Reads the reference temperature from the register'''
+        """Reads the reference temperature from the register"""
         raw_read = unpack(">h", self._read_register(_MAX31856_CJTH_REG, 2))[0]
 
         # effectively shift raw_read >> 8 to convert pseudo-float
@@ -277,13 +275,12 @@ class MAX31856:
         # wait for the measurement to complete
         self._wait_for_oneshot()
 
-
     def initiate_one_shot_measurement(self):
-        '''Starts a one-shot measurement and returns immediately.
+        """Starts a one-shot measurement and returns immediately.
         A measurement takes approximately 160ms.
         Check the status of the measurement with `oneshot_pending`; when it is false,
         the measurement is complete and the value can be read with `unpack_temperature`.
-        '''
+        """
         # read the current value of the first config register
         conf_reg_0 = self._read_register(_MAX31856_CR0_REG, 1)[0]
 
@@ -295,19 +292,19 @@ class MAX31856:
         # write it back with the new values, prompting the sensor to perform a measurement
         self._write_u8(_MAX31856_CR0_REG, conf_reg_0)
 
-
     @property
     def oneshot_pending(self) -> bool:
-        '''A boolean indicating the status of the one-shot flag.
-            A True value means the measurement is still ongoing.
-            A False value means measurement is complete.'''
-        oneshot_flag = self._read_register(_MAX31856_CR0_REG, 1)[0] & _MAX31856_CR0_1SHOT
+        """A boolean indicating the status of the one-shot flag.
+        A True value means the measurement is still ongoing.
+        A False value means measurement is complete."""
+        oneshot_flag = (
+            self._read_register(_MAX31856_CR0_REG, 1)[0] & _MAX31856_CR0_1SHOT
+        )
         return bool(oneshot_flag)
 
     def _wait_for_oneshot(self):
         while self.oneshot_pending:
             sleep(0.01)
-
 
     def _read_register(self, address, length):
         # pylint: disable=no-member

--- a/adafruit_max31856.py
+++ b/adafruit_max31856.py
@@ -164,7 +164,8 @@ class MAX31856:
 
     @property
     def temperature(self):
-        """Measure the temperature of the sensor and wait to retrieve its value in degrees Celsius. (read-only)"""
+        """Measure the temperature of the sensor and wait for the result.
+        Return value is in degrees Celsius. (read-only)"""
         self._perform_one_shot_measurement()
         return self.unpack_temperature()
 
@@ -279,7 +280,7 @@ class MAX31856:
 
     def initiate_one_shot_measurement(self):
         '''Starts a one-shot measurement and returns immediately.
-        A measurement takes approximately 160ms. 
+        A measurement takes approximately 160ms.
         Check the status of the measurement with `oneshot_pending`; when it is false,
         the measurement is complete and the value can be read with `unpack_temperature`.
         '''
@@ -297,8 +298,9 @@ class MAX31856:
 
     @property
     def oneshot_pending(self) -> bool:
-        '''A boolean indicating the status of the one-shot flag. 
-            A True value means the measurement is still ongoing. A False value means measurement is complete.'''
+        '''A boolean indicating the status of the one-shot flag.
+            A True value means the measurement is still ongoing.
+            A False value means measurement is complete.'''
         oneshot_flag = self._read_register(_MAX31856_CR0_REG, 1)[0] & _MAX31856_CR0_1SHOT
         return bool(oneshot_flag)
 


### PR DESCRIPTION
According to the MAX31856 datasheet, a one-shot temperature measurement takes approximately 160ms, and the ongoing status of the measurement can be queried by looking at the `CRO` register. However the current implementation in this library doesn't do this; it simply calls `sleep(0.250)` to block for 250ms upon triggering a measurement. Naturally this results in low performance if multiple sensors are used in parallel.

This PR improves performance by making the `.temperature` retrieval property return as soon as the measurement is complete.

Internally this is accomplished with new functions:

* .initiate_one_shot_measurement(), which returns immediately;
* .oneshot_pending, which queries the CRO register;
* ._wait_for_oneshot(), which checks .oneshot_pending in a loop every 10ms until the value is False;
* .unpack_temperature(), which retrieves the measurement from the register.

A developer may use these functions to read multiple MAX31856 sensors in parallel simultaneously because one is not blocking the other.

The original `.temperature` property still performs a blocking temperature retrieval to maintain expected behaviour, but it is refactored to use these functions, and now takes ~160ms instead of 250ms.

Tested on a Feather ESP32-S2 with two MAX31856 sensors.